### PR TITLE
Fix gauge installation and initialisation command

### DIFF
--- a/source/posts/2018-10-23-taiko-beta-reliable-browser-automation.html.markdown.erb
+++ b/source/posts/2018-10-23-taiko-beta-reliable-browser-automation.html.markdown.erb
@@ -122,9 +122,10 @@ Taiko works on Windows, MacOS and Linux.
 
 You need to have [Node.js](https://nodejs.org) installed in your system to start writing Taiko scripts in JavaScript. After you’ve installed Node.js, open a terminal application (or powershell in the case of Windows). 
 
-Install Gauge and Taiko using `npm` and then initialize a sample project using
+Install Gauge and Taiko using `npm` 
+    npm install -g @getgauge/cli    
 
-    npm install @getgauge/cli
+and initialize a sample project using
     gauge init js
 
 After creating your project, you can run the sample specification.


### PR DESCRIPTION
* Use global installation for Gauge npm gauge as command line
* Move `gauge init` to another step as commands for creating directories are different on windows and *nix