### PR TITLE
fix on link with disqus share link - removed unnecassary '

### DIFF
--- a/source/layouts/post.erb
+++ b/source/layouts/post.erb
@@ -51,7 +51,7 @@
           *  LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables*/
 
           var disqus_config = function () {
-          this.page.url = "<%= config.base_url_for_blog_posts %>/<%= current_article.destination_path.sub('/index.html', '.html') %>";
+          this.page.url = "<%= config.base_url_for_blog_posts %><%= current_article.destination_path.sub('/index.html', '') %>";
           this.page.identifier = this.page.url; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
           this.shortname = 'gaugeblog';
           };


### PR DESCRIPTION
Fix for disqus link share 

- - Removed unnecessary slash and .html extension under post.erb layout  
