### PR TITLE
Update links for `gauge-maven-plugin` & `gauge-gradle-plugin`.

### DIFF
--- a/source/plugins/index.html.erb
+++ b/source/plugins/index.html.erb
@@ -176,17 +176,17 @@ Let us know if you are working on a plugin, and we will list it here.
           </li>
           <li class="flex-container__item">
             <div class="plugin_name">
-               <a href="https://github.com/getgauge/gauge-maven-plugin/releases"  ><img src="/assets/images/Plugin-icons/maven.svg" class="icon-md">Maven</a>
+               <a href="https://github.com/getgauge-contrib/gauge-maven-plugin"  ><img src="/assets/images/Plugin-icons/maven.svg" class="icon-md">Maven</a>
             </div>
             <div class="more">To build and manage project dependencies. <a href="https://docs.gauge.org/latest/configuration.html#maven"  > Read more</a></div>
             <div class="owner"> <a href="https://www.thoughtworks.com/products">ThoughtWorks Inc.</a></div>
           </li>
           <li class="flex-container__item">
             <div class="plugin_name">
-               <a href="https://github.com/manupsunny/gauge-gradle-plugin/releases"  ><img src="/assets/images/Plugin-icons/gradle.svg" class="icon-md">Gradle</a>
+               <a href="https://github.com/getgauge/gauge-gradle-plugin"  ><img src="/assets/images/Plugin-icons/gradle.svg" class="icon-md">Gradle</a>
             </div>
             <div class="more">To build and manage project dependencies. <a href="https://docs.gauge.org/latest/configuration.html#gradle"  > Read more</a></div>
-            <div class="owner"> <a href="https://github.com/manupsunny">Manu Sunny</a></div>
+            <div class="owner"> <a href="https://www.thoughtworks.com/products">ThoughtWorks Inc.</a></div>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
Both are no longer released via GitHub releases (the releases are outdated); and the `gauge-gradle-plugin` is now owned/maintained by the ThoughtWorks Gauge team rather than the original writer.