### PR TITLE
Stop ai bot crawlers from indexing the main website

### DIFF
--- a/source/robots.txt.erb
+++ b/source/robots.txt.erb
@@ -2,6 +2,44 @@
 User-agent: *
 Disallow: /
 <% else %>
+# Block AI/ML training bots
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+# Allow regular bots
 User-agent: *
 Allow: /
 


### PR DESCRIPTION
Stop AI bot crawlers from indexing the website as this information is only useful for search bots.