### PR TITLE
Remove broken links from footer

### DIFF
--- a/source/partials/_footer.html.erb
+++ b/source/partials/_footer.html.erb
@@ -7,8 +7,7 @@
           <li> <a href="https://docs.gauge.org/getting_started/installing-gauge.html">Get started</a> </li>
           <li> <a href="/plugins/">Plugins</a> </li>
           <li> <a href="https://docs.gauge.org" >Documentation</a> </li>
-          <li> <a href="/blog">Blog</a></li>
-          <li> <a href="https://brand.gauge.org">Brand Style Guide</a></li> 
+          <li> <a href="/blog">Blog</a></li> 
         </ul>
       </nav>
     </div>
@@ -17,7 +16,6 @@
       <nav class="footer_links">
         <ul class="foolinks">
         <li> <a href="https://taiko.dev/">Taiko</a> </li>
-          <li> <a href="https://manpage.gauge.org/">Gauge Commands</a> </li>
           <li> <a href="https://www.thoughtworks.com/privacy-policy">Privacy</a> </li>
           <li> <a href="https://github.com/getgauge/gauge/blob/master/LICENSE">Apache License 2.0</a> </li>                
         </ul>
@@ -27,7 +25,6 @@
       <div class="heading">Engage</div>
       <nav class="footer_links">
         <ul class="foolinks">
-          <li> <a href="https://spectrum.chat/gauge?tab=posts" class="icon_spectrum">Spectrum</a> </li>
           <li> <a href="https://groups.google.com/forum/#!forum/getgauge"  class="icon_google">Google Group</a> </li>
           <li> <a href="https://github.com/getgauge/gauge/blob/master/CONTRIBUTING.md"  class="icon_contribute" >Contribute</a> </li>  
         </ul>


### PR DESCRIPTION
- Remove Brand Style Guide link (https://brand.gauge.org) - 404 error
- Remove Gauge Commands link (https://manpage.gauge.org/) - 404 error
- Remove Spectrum link (https://spectrum.chat/gauge?tab=posts) - redirects to 404

All remaining footer links have been verified as working.